### PR TITLE
선택한 멤버 강제 탈퇴 기능 구현

### DIFF
--- a/src/components/MemberList.jsx
+++ b/src/components/MemberList.jsx
@@ -49,7 +49,7 @@ const ProfileImage = styled.img`
 `;
 
 export default function MemberList({
-  totalMembers, selectUser, changeGrade, userAllCheck, members, user,
+  totalMembers, selectUser, changeGrade, userAllCheck, members, user, removeUser,
 }) {
   const handleChangeCheck = (checked, userId) => {
     selectUser.isChecked(checked, userId);
@@ -57,6 +57,10 @@ export default function MemberList({
 
   const handleClickGrade = () => {
     changeGrade(selectUser.checkUsers);
+  };
+
+  const handleClickRemove = () => {
+    removeUser();
   };
 
   const handleChangeGrade = (target) => {
@@ -200,7 +204,7 @@ export default function MemberList({
           </select>
           <span>(으)로</span>
           <button type="button" onClick={handleClickGrade}>변경</button>
-          <button type="button">강제 탈퇴</button>
+          <button type="button" onClick={handleClickRemove}>강제 탈퇴</button>
         </div>
       </div>
     </Container>

--- a/src/components/MemberList.test.jsx
+++ b/src/components/MemberList.test.jsx
@@ -6,6 +6,8 @@ const changeGrade = jest.fn();
 
 const userAllCheck = jest.fn();
 
+const removeUser = jest.fn();
+
 const context = describe;
 
 let members = {};
@@ -61,6 +63,7 @@ describe('MemberList', () => {
       userAllCheck={userAllCheck}
       members={members}
       user={user}
+      removeUser={removeUser}
     />);
   });
 
@@ -122,6 +125,14 @@ describe('MemberList', () => {
       expect(members.searchMember).toBeCalled();
 
       screen.getByText(/피카츄/);
+    });
+  });
+
+  context('멤버를 탈퇴시킬 경우', () => {
+    it('선태한 사용자를 탈퇴시킬 수 있다.', () => {
+      fireEvent.click(screen.getByText('강제 탈퇴'));
+
+      expect(removeUser).toBeCalled();
     });
   });
 });

--- a/src/pages/MemeberListPage.jsx
+++ b/src/pages/MemeberListPage.jsx
@@ -52,6 +52,10 @@ export default function MemberListPage() {
     setCheckUsers([]);
   };
 
+  const removeUser = async () => {
+    await memberStore.removeUser(checkUsers);
+  };
+
   const userAllCheck = (checked) => {
     if (checked) {
       const userIds = [];
@@ -88,6 +92,7 @@ export default function MemberListPage() {
       userAllCheck={userAllCheck}
       members={members}
       user={memberStore.user}
+      removeUser={removeUser}
     />
   );
 }

--- a/src/pages/MemeberListPage.test.jsx
+++ b/src/pages/MemeberListPage.test.jsx
@@ -8,6 +8,8 @@ const makeUserArray = jest.fn();
 
 const changeGrade = jest.fn();
 
+const removeUser = jest.fn();
+
 const searchMember = jest.fn();
 
 let totalMembers = [];
@@ -20,6 +22,7 @@ jest.mock('../hooks/useMemberStore', () => () => ({
   fetchUsers,
   makeUserArray,
   changeGrade,
+  removeUser,
   totalMembers,
   searchMember,
   errorMessage,

--- a/src/services/MemberApiService.js
+++ b/src/services/MemberApiService.js
@@ -23,6 +23,16 @@ export default class MemberApiService {
     });
   }
 
+  async removeUser(checkedUserId) {
+    const url = `${baseUrl}/admin-users`;
+
+    axios.delete(url, {
+      data: {
+        usersId: checkedUserId,
+      },
+    });
+  }
+
   async searchMember(member) {
     const url = `${baseUrl}/admin-user`;
 

--- a/src/stores/MemberStore.js
+++ b/src/stores/MemberStore.js
@@ -31,6 +31,14 @@ export default class MemberStore extends Store {
     this.publish();
   }
 
+  async removeUser(checkedUserId) {
+    await memberApiService.removeUser(checkedUserId);
+
+    this.fetchUsers();
+
+    this.publish();
+  }
+
   async searchMember(member) {
     try {
       const data = await memberApiService.searchMember(member);


### PR DESCRIPTION
- 선택한 유저의 아이디를 배열에 담아 강제 탈퇴 버튼을 누르면 해당 배열을 백엔드로 전달해 사용자 정보 db에서 제거
- 사용자를 지우기 위해선 게시글이나 댓글 대댓글을 지워야하고 게시글을 지울땐 해당 게시글에 다른 유저가 작성한 댓글이나 대댓글도 지워지도록 함