### PR TITLE
전체 멤버 수, 게시글 수, 등업 승인 대기자 수 종합 및 대시보드 1차 css 적용

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,22 +18,12 @@ const Container = styled.div`
   min-height: 100vh;
 `;
 
-const Body = styled.div`
-  display: flex;
-  height: 100vh;
-`;
-
-const MenuList = styled.div`
-  display: inline-block;
-  height: 100%;
-  width: 23%;
-  background-color: #DAEAF1;
-`;
-
 const Content = styled.div`
-  display: inline-flex;
-  height: 100%;
-  width: 77%;
+  display: flex;
+  flex-direction: column;
+  margin: 0 auto;
+  max-width: 1080px;
+  min-width: 1072px;
 `;
 
 export default function App() {
@@ -41,21 +31,17 @@ export default function App() {
     <Container>
       <Reset />
       <GlobalStyle />
-      <Body>
-        <MenuList>
-          <Menu />
-        </MenuList>
-        <Content>
-          <Routes>
-            <Route path="/" element={<DashBoardPage />} />
-            <Route path="manage-members" element={<MemberListPage />} />
-            <Route path="manage-levelup" element={<GradeBoardPage />} />
-            <Route path="manage-board" element={<ManageBoardPage />} />
-            <Route path="statistics" element={<StatisticsPage />} />
-            <Route path="/chart" element={<ChartPage />} />
-          </Routes>
-        </Content>
-      </Body>
+      <Menu />
+      <Content>
+        <Routes>
+          <Route path="/" element={<DashBoardPage />} />
+          <Route path="manage-members" element={<MemberListPage />} />
+          <Route path="manage-levelup" element={<GradeBoardPage />} />
+          <Route path="manage-board" element={<ManageBoardPage />} />
+          <Route path="statistics" element={<StatisticsPage />} />
+          <Route path="/chart" element={<ChartPage />} />
+        </Routes>
+      </Content>
     </Container>
   );
 }

--- a/src/components/DashBoard.jsx
+++ b/src/components/DashBoard.jsx
@@ -1,5 +1,8 @@
 /* eslint-disable react/prop-types */
 import styled from 'styled-components';
+import useGradeStore from '../hooks/useGradeStore';
+import useMemberStore from '../hooks/useMemberStore';
+import usePostStore from '../hooks/usePostStore';
 
 import ChartPage from '../pages/ChartPage';
 
@@ -11,10 +14,9 @@ const Container = styled.div`
   padding: 1em;
   gap: 1em;
   grid-template-columns: 1fr 1fr;
-	grid-template-rows: 1fr 1fr 1fr;
+	grid-template-rows: 1fr 1fr;
   grid-template-areas:
-  "myInformation todayStatistics"
-  ". ."
+  "member todayStatistics"
   "lineChart pieChart";
   background-color: #F9F2ED;
 
@@ -35,10 +37,23 @@ const TodayStatistics = styled.div`
   grid-template-columns: 1fr 1fr;
 	grid-template-rows: 1fr 1fr;
   grid-template-areas:
-  "posts comments"
-  "members .";
-  grid-area: todayStatistics;
+  "members comments"
+  "posts posts";
+  gap: 1em;
   background-color: #FFF;
+  grid-area: todayStatistics;
+`;
+
+const Member = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+	grid-template-rows: 1fr 1fr;
+  grid-template-areas:
+  "members grade"
+  "posts posts";
+  gap: 1em;
+  background-color: #F9F2ED;
+  grid-area: member;
 `;
 
 const BoardPieChart = styled.div`
@@ -52,7 +67,69 @@ const BoardPieChart = styled.div`
 const Posts = styled.div`
   border: 1px solid #CCC;
   grid-area: posts;
-  
+`;
+
+const Members = styled.div`
+  display: flex;
+  border-radius: 20px;
+  padding-left: 2em;
+  text-align: center;
+  align-items: center;
+  background-color: #FFF;
+  grid-area: members;
+
+  div:nth-child(2) {
+    margin-left: 2em;
+  }
+`;
+
+const Grade = styled.div`
+  display: flex;
+  text-align: center;
+  align-items: center;
+  padding-left: 1.4em;
+  border-radius: 20px;
+  background-color: #FFF;
+  grid-area: grade;
+
+  div:nth-child(2) {
+    margin-left: 2em;
+  }
+`;
+
+const TotalPosts = styled.div`
+  display: flex;
+  text-align: center;
+  align-items: center;
+  padding-left: 2.2em;
+  border-radius: 20px;
+  background-color: #FFF;
+  grid-area: posts;
+
+  div:nth-child(2) {
+    margin-left: 2em;
+  }
+`;
+
+const MemberIcon = styled.div`
+  width: 3em;
+  height: 3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206388367-71a42f25-14e6-4c23-8b38-9cec769d82d9.png");
+  background-size: cover;
+`;
+
+const PostIcon = styled.div`
+  width: 3em;
+  height: 3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206385522-ae016b0e-153d-40e8-9b61-42053c0bf6da.png");
+  background-size: cover;
+`;
+
+const GradeIcon = styled.div`
+  width: 3em;
+  height: 3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206390635-91b74a6e-d44b-4e17-8ebe-b048315b32ac.png");
+  background-size: cover;
 `;
 
 const Comments = styled.div`
@@ -60,7 +137,7 @@ const Comments = styled.div`
   grid-area: comments;
 `;
 
-const Members = styled.div`
+const TodayMembers = styled.div`
   border: 1px solid #CCC;
   grid-area: members;
 `;
@@ -72,6 +149,12 @@ const BoardLineChart = styled.div`
 `;
 
 export default function DashBoard({ statistics, boardRate }) {
+  const postStore = usePostStore();
+
+  const gradeStore = useGradeStore();
+
+  const memberStore = useMemberStore();
+
   return (
     <Container>
       <MyInformation />
@@ -90,14 +173,46 @@ export default function DashBoard({ statistics, boardRate }) {
             {statistics.todayWrittenCommentsNumber}
           </p>
         </Comments>
-        <Members>
+        <TodayMembers>
           <p>
             오늘 가입 멤버 수
             {' '}
             {statistics.todaySignupUserNumber}
           </p>
-        </Members>
+        </TodayMembers>
       </TodayStatistics>
+      <Member>
+        <Members>
+          <MemberIcon />
+          <div>
+            <p>전체 멤버 수</p>
+            <p>
+              {memberStore.usersNumber}
+              명
+            </p>
+          </div>
+        </Members>
+        <Grade>
+          <GradeIcon />
+          <div>
+            <p>등업 승인 대기자 수</p>
+            <p>
+              {gradeStore.processingApplications}
+              명
+            </p>
+          </div>
+        </Grade>
+        <TotalPosts>
+          <PostIcon />
+          <div>
+            <p>전체 게시글 수</p>
+            <p>
+              {postStore.totalPostNumber}
+              개
+            </p>
+          </div>
+        </TotalPosts>
+      </Member>
       <BoardPieChart>
         <h2>게시판별 게시글 비중</h2>
         <PieBoardChart

--- a/src/components/Menu.jsx
+++ b/src/components/Menu.jsx
@@ -3,44 +3,114 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Container = styled.div`
-  /* display: flex; */
-  width: 250px;
-
+  display: flex;
+  height: 100px;
+  min-width: 1072px;
+  background-color: #CD2C2C;
 `;
 
-const MyInformation = styled.div`
-  /* padding-top: 2em; */
+const Content = styled.nav`
+  display: flex;
+  width: 100%;
 `;
 
 const MenuList = styled.ul`
   display: flex;
-  justify-content: center;
-  text-align: center;
+  margin: auto;
+  min-width: 1072px;
 `;
 
 const Item = styled.li`
   display: flex;
-  flex-direction: column;
-  
+  width: 100%;
+  justify-content: space-around;
+ 
   a {
-    margin-bottom: 1.3em;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    color: #FFF;
+
+    div {
+      margin-bottom: 0.4em;
+    }
   }
+`;
+
+const HomeIcon = styled.div`
+  width: 3em;
+  height: 3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206433181-109f8eb5-b2a1-4c6a-a3e0-47124824f5c7.png");
+  background-size: cover;
+`;
+
+const MemberIcon = styled.div`
+  width: 3.3em;
+  height: 3.3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206444163-2c1d2ef1-5d7b-494e-b0c0-3fae03479cc0.png");
+  background-size: cover;
+`;
+
+const GradeIcon = styled.div`
+  width: 3em;
+  height: 3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206434212-21cb5f71-6c29-44e2-8698-40bc82f72da8.png");
+  background-size: cover;
+`;
+
+const BoardIcon = styled.div`
+  width: 3em;
+  height: 3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206435495-bdd984c8-4579-44bd-bda7-541eb6526720.png");
+  background-size: cover;
+`;
+
+const StatisticsIcon = styled.div`
+  width: 3em;
+  height: 3em;
+  background: url("https://user-images.githubusercontent.com/104769120/206435697-2b152fc1-5a63-41da-bd90-a67e1ded35d6.png");
+  background-size: cover;
 `;
 
 export default function Menu() {
   return (
     <Container>
-      <MyInformation />
-      <nav>
+      <Content>
         <MenuList>
           <Item>
-            <Link to="/manage-members">멤버 관리</Link>
-            <Link to="/manage-levelup">등업 신청 관리</Link>
-            <Link to="/manage-board">게시판 관리</Link>
-            <Link to="/statistics">통계</Link>
+            <div>
+              <Link to="/">
+                <HomeIcon />
+                홈 화면
+              </Link>
+            </div>
+            <div>
+              <Link to="/manage-members">
+                <MemberIcon />
+                멤버 관리
+              </Link>
+            </div>
+            <div>
+              <Link to="/manage-levelup">
+                <GradeIcon />
+                등업 신청 관리
+              </Link>
+            </div>
+            <div>
+              <Link to="/manage-board">
+                <BoardIcon />
+                게시판 관리
+              </Link>
+            </div>
+            <div>
+              <Link to="/statistics">
+                <StatisticsIcon />
+                통계
+              </Link>
+            </div>
           </Item>
         </MenuList>
-      </nav>
+      </Content>
     </Container>
   );
 }

--- a/src/pages/DashBoardPage.jsx
+++ b/src/pages/DashBoardPage.jsx
@@ -10,6 +10,8 @@ import useCommentStore from '../hooks/useCommentStore';
 
 import useBoardStore from '../hooks/useBoardStore';
 
+import useGradeStore from '../hooks/useGradeStore';
+
 export default function DashBoardPage() {
   const boardStore = useBoardStore();
 
@@ -19,11 +21,16 @@ export default function DashBoardPage() {
 
   const commentStore = useCommentStore();
 
+  const gradeStore = useGradeStore();
+
   useEffect(() => {
     boardStore.fetchBoardRate();
     postStore.fetchTodayPosts();
+    postStore.fetchPosts();
     memberStore.fetchTodaySignupNumber();
+    memberStore.fetchUsers();
     commentStore.fetchTodayComment();
+    gradeStore.fetchProcessingApplication();
   }, []);
 
   const { boardRate } = boardStore;

--- a/src/services/GradeApiService.js
+++ b/src/services/GradeApiService.js
@@ -14,6 +14,14 @@ export default class GradeApiService {
     return data;
   }
 
+  async fetchProcessingApplication() {
+    const url = `${baseUrl}/admin-processing-posts`;
+
+    const { data } = await axios.get(url);
+
+    return data;
+  }
+
   async updateGrade(postId, applicationGrade, name) {
     const url = `${baseUrl}/admin-grade`;
 

--- a/src/services/PostApiService.js
+++ b/src/services/PostApiService.js
@@ -6,6 +6,14 @@ import config from '../config';
 const baseUrl = config.apiBaseUrl;
 
 export default class PostApiService {
+  async fetchPosts() {
+    const url = `${baseUrl}/admin-total-posts`;
+
+    const { data } = await axios.get(url);
+
+    return data;
+  }
+
   async fetchMostHitPosts() {
     const url = `${baseUrl}/admin-most-hit-posts`;
 

--- a/src/stores/GradeStore.js
+++ b/src/stores/GradeStore.js
@@ -7,12 +7,22 @@ export default class GradeStore extends Store {
     super();
 
     this.applicationPosts = [];
+
+    this.processingApplications = 0;
   }
 
   async fetchApplication() {
     const data = await gradeApiService.fetchApplication();
 
     this.applicationPosts = data.applicationPosts;
+
+    this.publish();
+  }
+
+  async fetchProcessingApplication() {
+    const data = await gradeApiService.fetchProcessingApplication();
+
+    this.processingApplications = data;
 
     this.publish();
   }

--- a/src/stores/MemberStore.js
+++ b/src/stores/MemberStore.js
@@ -12,6 +12,8 @@ export default class MemberStore extends Store {
 
     this.user = {};
 
+    this.usersNumber = 0;
+
     this.todaySignupUserNumber = 0;
 
     this.searchState = '';
@@ -21,6 +23,8 @@ export default class MemberStore extends Store {
     const data = await memberApiService.fetchUsers();
 
     this.members = data.members;
+
+    this.usersNumber = data.members.users.length;
 
     this.publish();
   }

--- a/src/stores/PostStore.js
+++ b/src/stores/PostStore.js
@@ -11,7 +11,16 @@ export default class PostStore extends Store {
 
     this.postsByDate = {};
 
+    this.totalPostNumber = 0;
     this.todayCreatedPostsNumber = 0;
+  }
+
+  async fetchPosts() {
+    const data = await postApiService.fetchPosts();
+
+    this.totalPostNumber = data;
+
+    this.publish();
   }
 
   async fetchMostHitPosts() {


### PR DESCRIPTION
- 전체 멤버수와 전체 게시글 수, 현재 등업 승인을 기다리는 멤버의 수를 종합하여 대시보드 페이지에서 확인할 수 있도록 함
- 대시보드 페이지 grid를 이용해 요소들 배치